### PR TITLE
fix bei 5 Parteien + Sonstige im kleinen Widget

### DIFF
--- a/Sonntagsfrage.js
+++ b/Sonntagsfrage.js
@@ -264,7 +264,7 @@ async function createWidget() {
   list.url = 'scriptable:///run/Sonntagsfrage/?p=' + requestParliaments;
   
   if (typeof(requestParliaments) === 'string' && requestParliaments.indexOf(',') > 0) {
-    requestParliamens = requestParliaments.replace(/[^0-9,]/g, '');
+    requestParliaments = requestParliaments.replace(/[^0-9,]/g, '');
     requestParliaments = requestParliaments.split(',');
   }
   
@@ -331,8 +331,10 @@ async function createWidget() {
     const v = parseFloat(poll.results[i][1]);
     
     if (p === "0" && (widgetSize != 'large' && ignoreOthersOnSmallAndMedium)) {
-      maxParties++;
-      continue;
+      if (maxParties < poll.results.length) {
+        maxParties++;
+        continue;
+      }
     }
 
     const party = parties.find(elem => elem.id === p);


### PR DESCRIPTION
Wenn es nur maxParties Parteien gibt und eine davon Sonstige ist, darf nicht maxParties erhöht werden. In dem Fall kann man dann auch die Sonstigen anzeigen, der Platz ist da und es gibt sonst nichts anzuzeigen.

Tippfehler im Variablennamen korrigiert, so dass der replace auch funktionieren kann.